### PR TITLE
Add support for multiple image uploads with per-image processing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -260,7 +260,8 @@ const App: React.FC = () => {
       });
       setShowOriginal(false);
     } catch (err) {
-      console.error("Failed to read one or more image files:", err instanceof Error ? err.message : "Unknown error");
+      const safeMsg = err instanceof Error ? err.message : "Unknown error";
+      console.error("Failed to read one or more image files:", safeMsg);
       setState(prev => ({
         ...prev,
         error: "Failed to read one or more image files. Please try again.",

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback, useMemo, useEffect } from 'react';
-import { Detection, AppState } from './types';
+import { Detection, AppState, ImageItem } from './types';
 import { analyzeImageForPII } from './services/gemini';
 import Logo from './Logo';
 import { 
@@ -19,7 +19,8 @@ import {
   ChevronDown,
   ChevronRight,
   Zap,
-  Info
+  Info,
+  UploadCloud
 } from 'lucide-react';
 
 const SCAN_MESSAGES = [
@@ -39,6 +40,8 @@ const App: React.FC = () => {
     isAnalyzing: false,
     detections: [],
     error: null,
+    images: [],
+    activeImageId: null,
   });
   
   const [redactionColor, setRedactionColor] = useState('#000000');
@@ -48,10 +51,25 @@ const App: React.FC = () => {
   const [scanMessageIndex, setScanMessageIndex] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Derive active image's analyzing state
+  const activeImage = state.images.find(img => img.id === state.activeImageId);
+  const isActiveImageAnalyzing = activeImage?.isAnalyzing ?? false;
+
+  // Cleanup blob URLs only on component unmount
+  useEffect(() => {
+    return () => {
+      state.images.forEach(img => {
+        if (img.src.startsWith('blob:')) {
+          URL.revokeObjectURL(img.src);
+        }
+      });
+    };
+  }, []);
+
   // Cycle messages during scan
   useEffect(() => {
     let interval: number;
-    if (state.isAnalyzing) {
+    if (isActiveImageAnalyzing) {
       interval = window.setInterval(() => {
         setScanMessageIndex((prev) => (prev + 1) % SCAN_MESSAGES.length);
       }, 1500);
@@ -59,9 +77,9 @@ const App: React.FC = () => {
       setScanMessageIndex(0);
     }
     return () => clearInterval(interval);
-  }, [state.isAnalyzing]);
+  }, [isActiveImageAnalyzing]);
 
-  const optimizeImage = (base64: string): Promise<string> => {
+  const optimizeImage = (imageSource: string): Promise<string> => {
     return new Promise((resolve) => {
       const img = new Image();
       img.onload = () => {
@@ -87,81 +105,281 @@ const App: React.FC = () => {
         canvas.height = height;
         const ctx = canvas.getContext('2d');
         ctx?.drawImage(img, 0, 0, width, height);
-        resolve(canvas.toDataURL('image/jpeg', 0.85));
+        // Return the full data URL (gemini.ts will strip the prefix)
+        const dataUrl = canvas.toDataURL('image/jpeg', 0.85);
+        resolve(dataUrl);
       };
-      img.src = base64;
+      img.src = imageSource;
     });
-  };
-
-  const handleSetImage = (base64: string, name: string) => {
-    setState({
-      image: base64,
-      fileName: name,
-      isAnalyzing: false,
-      detections: [],
-      error: null,
-    });
-    setShowOriginal(false);
   };
 
   const handleStartScan = async () => {
-    if (!state.image) return;
-    setState(prev => ({ ...prev, isAnalyzing: true, error: null }));
+    if (!state.activeImageId) return;
+    const targetId = state.activeImageId;
+    const targetImage = state.images.find(img => img.id === targetId);
+    
+    if (!targetImage) return;
+
+    setState(prev => ({
+      ...prev,
+      images: prev.images.map(img =>
+        img.id === targetId ? { ...img, isAnalyzing: true, error: null } : img
+      ),
+    }));
     
     try {
-      const optimizedImage = await optimizeImage(state.image);
-      const results = await analyzeImageForPII(optimizedImage);
+      // Create lightweight blob URL instead of converting to base64 string
+      const blobUrl = URL.createObjectURL(targetImage.file);
+      try {
+        const optimizedImage = await optimizeImage(blobUrl);
+        const results = await analyzeImageForPII(optimizedImage);
       
-      setState(prev => ({ 
-        ...prev, 
-        detections: results, 
-        isAnalyzing: false 
-      }));
+      setState(prev => {
+        const images = prev.images.map(img =>
+          img.id === targetId ? { ...img, isAnalyzing: false, detections: results } : img
+        );
+        const activeImage = images.find(img => img.id === prev.activeImageId);
+
+        return {
+          ...prev,
+          detections: activeImage ? activeImage.detections : prev.detections,
+          error: activeImage ? activeImage.error : prev.error,
+          images,
+        };
+      });
       
-      const uniqueLabels = Array.from(new Set(results.map(r => r.label)));
-      setExpandedCategories(uniqueLabels.reduce((acc, label) => ({ ...acc, [label]: true }), {}));
+        const uniqueLabels = Array.from(new Set(results.map(r => r.label)));
+        setExpandedCategories(uniqueLabels.reduce((acc: Record<string, boolean>, label: string) => ({ ...acc, [label]: true }), {}));
+      } finally {
+        // Always clean up the blob URL to free memory
+        URL.revokeObjectURL(blobUrl);
+      }
     } catch (err: any) {
-      setState(prev => ({ 
-        ...prev, 
-        isAnalyzing: false, 
-        error: "Privacy scan failed. Check network or API limits." 
+      const errorMessage = err?.message ?? "Unknown error";
+      console.error("Privacy scan failed:", errorMessage);
+      const msg = String(err?.message ?? err?.error?.message ?? JSON.stringify(err ?? ""));
+      let friendlyError = "Privacy scan failed. Check network or API limits.";
+      if (msg.includes("Missing GEMINI_API_KEY")) {
+        friendlyError = "GEMINI_API_KEY is missing. Check your .env file and restart `npm run dev`.";
+      } else if (msg.includes("leaked") || msg.includes("Please use another API key")) {
+        friendlyError = "Your API key was reported as leaked. Create a new key at aistudio.google.com/apikey and update GEMINI_API_KEY in .env";
+      }
+
+      setState(prev => ({
+        ...prev,
+        images: prev.images.map(img =>
+          img.id === targetId ? { ...img, isAnalyzing: false, error: friendlyError } : img
+        ),
+        error: prev.activeImageId === targetId ? friendlyError : prev.error,
       }));
     }
   };
 
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = (event) => {
-      const base64 = event.target?.result as string;
-      handleSetImage(base64, file.name);
-    };
-    reader.readAsDataURL(file);
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    // Check if adding new files would exceed 10 total images
+    const totalImages = state.images.length + files.length;
+    if (totalImages > 10) {
+      const excessCount = totalImages - 10;
+      setState(prev => ({
+        ...prev,
+        error: `You can upload up to 10 images total. You have ${state.images.length} images. Please select ${10 - state.images.length} or fewer images.`,
+      }));
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+      return;
+    }
+
+    const allFiles = Array.from(files);
+    const imageFiles = allFiles.filter((file): file is File => file instanceof File && file.type.startsWith('image/'));
+
+    if (imageFiles.length === 0) {
+      setState(prev => ({
+        ...prev,
+        error: "Only image files are supported. Please select valid image formats.",
+      }));
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+      return;
+    }
+
+    if (imageFiles.length !== allFiles.length) {
+      setState(prev => ({
+        ...prev,
+        error: "Some files were skipped because they are not supported image formats.",
+      }));
+    }
+
+    const filePromises = imageFiles.map(
+      (file) =>
+        new Promise<{ file: File; src: string }>((resolve, reject) => {
+          try {
+            const blobUrl = URL.createObjectURL(file);
+            resolve({ file, src: blobUrl });
+          } catch (err) {
+            reject(err);
+          }
+        })
+    );
+
+    try {
+      const results = await Promise.all(filePromises);
+      const timestamp = Date.now();
+
+      const newImages: ImageItem[] = results.map((result, index) => ({
+        id: `img-${timestamp}-${index}`,
+        fileName: result.file.name,
+        src: result.src,
+        file: result.file,
+        detections: [],
+        isAnalyzing: false,
+        error: null,
+      }));
+
+      setState(prev => {
+        // Append new images to existing ones
+        const combinedImages = [...prev.images, ...newImages];
+
+        // If no active image, set the first new image as active
+        const activeImageId = prev.activeImageId || newImages[0].id;
+        const activeImage = combinedImages.find(img => img.id === activeImageId);
+
+        return {
+          ...prev,
+          images: combinedImages,
+          activeImageId: activeImageId,
+          image: activeImage?.src || prev.image,
+          fileName: activeImage?.fileName || prev.fileName,
+          detections: activeImage?.detections || prev.detections,
+          error: null,
+        };
+      });
+      setShowOriginal(false);
+    } catch (err) {
+      console.error("Failed to read one or more image files:", err instanceof Error ? err.message : "Unknown error");
+      setState(prev => ({
+        ...prev,
+        error: "Failed to read one or more image files. Please try again.",
+      }));
+    }
   };
 
   const toggleCategory = (label: string, shouldSelect: boolean) => {
-    setState(prev => ({
-      ...prev,
-      detections: prev.detections.map(d => d.label === label ? { ...d, selected: shouldSelect } : d)
-    }));
+    setState(prev => {
+      const updatedDetections = prev.detections.map(d =>
+        d.label === label ? { ...d, selected: shouldSelect } : d
+      );
+
+      const images = prev.images.map(img =>
+        img.id === prev.activeImageId
+          ? {
+              ...img,
+              detections: img.detections.map(d =>
+                d.label === label ? { ...d, selected: shouldSelect } : d
+              ),
+            }
+          : img
+      );
+
+      return {
+        ...prev,
+        detections: updatedDetections,
+        images,
+      };
+    });
   };
 
   const toggleDetection = (id: string) => {
-    setState(prev => ({
-      ...prev,
-      detections: prev.detections.map(d => d.id === id ? { ...d, selected: !d.selected } : d)
-    }));
+    setState(prev => {
+      const updatedDetections = prev.detections.map(d =>
+        d.id === id ? { ...d, selected: !d.selected } : d
+      );
+
+      const images = prev.images.map(img =>
+        img.id === prev.activeImageId
+          ? {
+              ...img,
+              detections: img.detections.map(d =>
+                d.id === id ? { ...d, selected: !d.selected } : d
+              ),
+            }
+          : img
+      );
+
+      return {
+        ...prev,
+        detections: updatedDetections,
+        images,
+      };
+    });
   };
 
   const removeImage = () => {
-    setState({ image: null, fileName: null, isAnalyzing: false, detections: [], error: null });
+    setState({
+      image: null,
+      fileName: null,
+      detections: [],
+      error: null,
+      images: [],
+      activeImageId: null,
+      isAnalyzing: false,
+    });
     if (fileInputRef.current) fileInputRef.current.value = '';
     setExpandedCategories({});
   };
 
+  const removeIndividualImage = (id: string) => {
+    setState(prev => {
+      // Revoke blob URL for this image
+      const imageToRemove = prev.images.find(img => img.id === id);
+      if (imageToRemove && imageToRemove.src.startsWith('blob:')) {
+        URL.revokeObjectURL(imageToRemove.src);
+      }
+
+      const remainingImages = prev.images.filter(img => img.id !== id);
+      
+      // If removing the active image, switch to the first remaining image
+      if (prev.activeImageId === id) {
+        const nextImage = remainingImages[0];
+        if (nextImage) {
+          return {
+            ...prev,
+            images: remainingImages,
+            activeImageId: nextImage.id,
+            image: nextImage.src,
+            fileName: nextImage.fileName,
+            detections: nextImage.detections,
+            error: nextImage.error,
+          };
+        } else {
+          // No images left
+          return {
+            ...prev,
+            images: [],
+            activeImageId: null,
+            image: null,
+            fileName: null,
+            detections: [],
+            error: null,
+          };
+        }
+      }
+      
+      return {
+        ...prev,
+        images: remainingImages,
+      };
+    });
+  };
+
   const downloadRedacted = useCallback(() => {
-    if (!state.image) return;
+    const activeImage = state.images.find(img => img.id === state.activeImageId);
+    if (!activeImage) return;
+    
     const img = new Image();
     img.onload = () => {
       const canvas = document.createElement('canvas');
@@ -184,11 +402,11 @@ const App: React.FC = () => {
         ctx.restore();
       });
       const link = document.createElement('a');
-      link.download = `redacted-${state.fileName}`;
+      link.download = `redacted-${activeImage.fileName}`;
       link.href = canvas.toDataURL('image/png');
       link.click();
     };
-    img.src = state.image;
+    img.src = activeImage.src;
   }, [state, redactionColor, redactionOpacity]);
 
   const getRGBA = (hex: string, alpha: number) => {
@@ -212,6 +430,26 @@ const App: React.FC = () => {
     }));
   }, [state.detections]);
 
+  const handleSelectImage = (id: string) => {
+    setState(prev => {
+      const image = prev.images.find(img => img.id === id);
+      if (!image) return prev;
+
+      const uniqueLabels = Array.from(new Set(image.detections.map(r => r.label)));
+      setExpandedCategories(uniqueLabels.reduce((acc: Record<string, boolean>, label: string) => ({ ...acc, [label]: true }), {}));
+
+      return {
+        ...prev,
+        activeImageId: id,
+        image: image.src,
+        fileName: image.fileName,
+        detections: image.detections,
+        error: image.error,
+      };
+    });
+    setShowOriginal(false);
+  };
+
   return (
     <div className="min-h-screen flex flex-col font-sans text-slate-200 bg-[#0f172a]">
       <header className="border-b border-slate-800 bg-slate-900/90 backdrop-blur-xl sticky top-0 z-50 shadow-lg h-16 shrink-0">
@@ -225,16 +463,33 @@ const App: React.FC = () => {
             </div>
           </div>
           <div className="flex items-center gap-3">
-            {state.image && !state.isAnalyzing && state.detections.length > 0 && (
+            <button
+              onClick={() => {
+                setState(prev => ({ ...prev, error: null }));
+                fileInputRef.current?.click();
+              }}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-[10px] font-black uppercase border border-indigo-500/40 bg-indigo-500/10 text-indigo-300 hover:bg-indigo-500/20 transition-all"
+            >
+              <UploadCloud className="w-3 h-3" />
+              Upload Images
+            </button>
+            {state.image && !isActiveImageAnalyzing && state.detections.length > 0 && (
               <button 
                 onClick={() => setShowOriginal(!showOriginal)} 
-                className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-[10px] font-black uppercase border transition-all ${showOriginal ? 'bg-amber-500/10 text-amber-500 border-amber-500/20' : 'bg-slate-800 border-slate-700 hover:bg-slate-700'}`}
+                className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-[10px] font-black uppercase border transition-all ${showOriginal ? 'bg-slate-800 border-slate-700 hover:bg-slate-700' : 'bg-amber-500/10 text-amber-500 border-amber-500/20'}`}
               >
                 {showOriginal ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />}
-                {showOriginal ? 'Apply Shields' : 'Reveal Sensitive Areas'}
+                {showOriginal ? 'Original' : 'Redacted'}
               </button>
             )}
-            <input type="file" ref={fileInputRef} className="hidden" accept="image/*" onChange={handleFileUpload} />
+            <input 
+              type="file" 
+              ref={fileInputRef} 
+              className="hidden" 
+              accept="image/*" 
+              multiple 
+              onChange={handleFileUpload} 
+            />
           </div>
         </div>
       </header>
@@ -255,11 +510,11 @@ const App: React.FC = () => {
             </div>
           ) : (
             <div className="relative bg-slate-900/50 border border-slate-800 rounded-[2.5rem] overflow-hidden flex items-center justify-center p-6 flex-1 shadow-2xl min-h-[300px] lg:min-h-0">
-              <div className="relative inline-block overflow-hidden rounded-2xl">
+              <div className="relative w-full h-full flex items-center justify-center overflow-hidden rounded-2xl bg-slate-950">
                 <img 
                   src={state.image} 
                   alt="Workspace" 
-                  className="max-w-full max-h-[70vh] block border border-slate-700 pointer-events-none" 
+                  className="w-full h-full object-contain block border border-slate-700 pointer-events-none" 
                 />
                 
                 {/* Overlay Bounding Boxes */}
@@ -285,7 +540,7 @@ const App: React.FC = () => {
                 })}
 
                 {/* Analysis State */}
-                {state.isAnalyzing && (
+                {isActiveImageAnalyzing && (
                   <div className="absolute inset-0 bg-[#0f172a]/95 backdrop-blur-md flex flex-col items-center justify-center z-50">
                     <Logo className="w-24 h-24 mb-8" isAnalyzing={true} />
                     <div className="flex flex-col items-center gap-4 text-center px-10">
@@ -302,6 +557,95 @@ const App: React.FC = () => {
               </div>
             </div>
           )}
+
+          {/* Image list/grid preview */}
+          {state.images.length > 0 && (
+            <div className="bg-slate-900/60 border border-slate-800 rounded-3xl p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-[10px] font-black uppercase tracking-widest text-slate-500 flex items-center gap-2">
+                  <ShieldCheck className="w-4 h-4 text-indigo-500" />
+                  Image Batch ({state.images.length}/10)
+                </h3>
+              </div>
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+                {state.images.map(image => {
+                  const isActive = image.id === state.activeImageId;
+                  const hasDetections = image.detections.length > 0;
+
+                  let statusLabel = 'Pending Scan';
+                  let statusClass = 'text-slate-500 bg-slate-900 border-slate-800';
+                  if (image.isAnalyzing) {
+                    statusLabel = 'Scanning...';
+                    statusClass = 'text-indigo-300 bg-indigo-500/10 border-indigo-500/30';
+                  } else if (image.error) {
+                    statusLabel = 'Error';
+                    statusClass = 'text-red-300 bg-red-500/10 border-red-500/30';
+                  } else if (hasDetections) {
+                    statusLabel = 'Redacted';
+                    statusClass = 'text-emerald-300 bg-emerald-500/10 border-emerald-500/30';
+                  }
+
+                  return (
+                    <div
+                      key={image.id}
+                      className={`group flex flex-col gap-2 p-2 rounded-2xl border text-left transition-all cursor-pointer ${
+                        isActive
+                          ? 'border-indigo-500/60 bg-slate-800/80 shadow-lg shadow-indigo-500/20'
+                          : 'border-slate-800 bg-slate-900/40 hover:border-indigo-500/40 hover:bg-slate-800/60'
+                      }`}
+                    >
+                      <div
+                        onClick={() => handleSelectImage(image.id)}
+                        className="w-full flex flex-col gap-2 cursor-pointer"
+                      >
+                        <div className="relative rounded-xl overflow-hidden border border-slate-800/60 h-20 bg-slate-900/60">
+                          <img
+                            src={image.src}
+                            alt={image.fileName}
+                            className="w-full h-full object-cover"
+                          />
+                          {image.isAnalyzing && (
+                            <div className="absolute inset-0 bg-slate-900/70 flex items-center justify-center text-[8px] font-black uppercase tracking-widest text-indigo-300">
+                              Scanning...
+                            </div>
+                          )}
+                          {/* Delete button overlay */}
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              removeIndividualImage(image.id);
+                            }}
+                            className="absolute top-1 right-1 p-1 bg-red-500/80 hover:bg-red-600 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity"
+                            title="Delete image"
+                          >
+                            <Trash2 className="w-3 h-3 text-white" />
+                          </button>
+                        </div>
+                        <div className="flex flex-col gap-1">
+                          <p className="text-[9px] font-bold text-slate-300 truncate">
+                            {image.fileName}
+                          </p>
+                          <div className="flex items-center justify-between">
+                            <span
+                              className={`text-[8px] font-black uppercase tracking-widest px-1.5 py-0.5 rounded border ${statusClass}`}
+                            >
+                              {statusLabel}
+                            </span>
+                            {hasDetections && (
+                              <span className="text-[8px] font-bold text-indigo-300">
+                                {image.detections.length} masks
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
           {state.error && (
             <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-2xl text-red-400 text-xs font-bold uppercase tracking-widest flex items-center gap-3">
               <AlertCircle className="w-5 h-5 shrink-0" /> 
@@ -317,22 +661,25 @@ const App: React.FC = () => {
             {/* Style Header */}
             <div className="p-6 pb-2 shrink-0">
               <h2 className="text-[10px] font-black text-slate-500 uppercase tracking-widest mb-4 flex items-center gap-2">
-                <Palette className="w-4 h-4 text-indigo-500" /> Masking Parameters
+                <Palette className="w-4 h-4 text-indigo-500" /> Mask Configuration
               </h2>
               <div className="bg-slate-800/30 p-4 rounded-2xl border border-slate-700/50 space-y-4">
-                <div className="flex flex-wrap gap-2">
-                  {['#000000', '#FFFFFF', '#ef4444', '#10b981', '#6366f1'].map(c => (
-                    <button 
-                      key={c} 
-                      onClick={() => setRedactionColor(c)} 
-                      className={`w-8 h-8 rounded-lg border-2 transition-all transform ${redactionColor === c ? 'border-indigo-500 scale-110 shadow-lg' : 'border-transparent opacity-40 hover:opacity-100'}`} 
-                      style={{ backgroundColor: c }} 
-                    />
-                  ))}
+                <div>
+                  <p className="text-[8px] font-black uppercase text-slate-500 mb-3">Redaction Color</p>
+                  <div className="flex flex-wrap gap-2">
+                    {['#000000', '#FFFFFF', '#ef4444', '#10b981', '#6366f1'].map(c => (
+                      <button 
+                        key={c} 
+                        onClick={() => setRedactionColor(c)} 
+                        className={`w-8 h-8 rounded-lg border-2 transition-all transform ${redactionColor === c ? 'border-indigo-500 scale-110 shadow-lg' : 'border-transparent opacity-40 hover:opacity-100'}`} 
+                        style={{ backgroundColor: c }} 
+                      />
+                    ))}
+                  </div>
                 </div>
                 <div className="space-y-1">
                   <div className="flex justify-between text-[8px] font-black uppercase text-slate-500">
-                    <span>Density</span>
+                    <span>Mask Density</span>
                     <span className="text-indigo-400">{Math.round(redactionOpacity * 100)}%</span>
                   </div>
                   <input 
@@ -347,9 +694,11 @@ const App: React.FC = () => {
 
             {/* Scrollable Detection List */}
             <div className="flex-1 overflow-hidden flex flex-col px-6">
-              <h2 className="text-[10px] font-black text-slate-500 uppercase tracking-widest mb-3 flex items-center gap-2 py-4 border-b border-slate-800 shrink-0">
-                <Filter className="w-4 h-4 text-indigo-500" /> Sensitive Objects Detected
-              </h2>
+              {!isActiveImageAnalyzing && (
+                <h2 className="text-[10px] font-black text-slate-500 uppercase tracking-widest mb-3 flex items-center gap-2 py-4 border-b border-slate-800 shrink-0">
+                  <Filter className="w-4 h-4 text-indigo-500" /> Sensitive Fields
+                </h2>
+              )}
               {/* This container will now scroll on all devices because its parent (sidebar) has a defined height */}
               <div className="flex-1 overflow-y-auto custom-scrollbar pr-2 space-y-3 pb-6 min-h-0">
                 {state.detections.length > 0 ? (
@@ -357,48 +706,40 @@ const App: React.FC = () => {
                     <div key={cat.label} className="bg-slate-800/20 rounded-xl overflow-hidden border border-slate-800/50">
                       <button 
                         onClick={() => setExpandedCategories(prev => ({...prev, [cat.label]: !prev[cat.label]}))}
-                        className="w-full flex items-center justify-between p-3 text-[10px] font-black uppercase tracking-wider hover:bg-slate-800/40 transition-colors"
+                        className="w-full flex items-center justify-between p-4 text-[11px] font-black uppercase tracking-wider hover:bg-slate-800/40 transition-colors"
                       >
-                        <div className="flex items-center gap-2">
-                          {expandedCategories[cat.label] ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                          <span className={cat.selectedCount > 0 ? "text-indigo-400" : "text-slate-500"}>{cat.label}s</span>
-                        </div>
                         <div className="flex items-center gap-3">
-                           <span className="text-[8px] text-slate-600 bg-slate-900 px-1.5 py-0.5 rounded border border-slate-800">{cat.selectedCount}/{cat.items.length}</span>
-                           <div 
-                             onClick={(e) => { e.stopPropagation(); toggleCategory(cat.label, !cat.allSelected); }}
-                             className={`p-1 rounded transition-colors ${cat.allSelected ? 'text-indigo-500' : 'text-slate-700 hover:text-slate-500'}`}
-                           >
-                             {cat.allSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
-                           </div>
+                          <CheckSquare className="w-5 h-5 text-emerald-500" />
+                          <span className="text-emerald-400">{cat.label}s</span>
                         </div>
+                        <span className="text-[9px] text-slate-400 bg-slate-900 px-2 py-1 rounded border border-slate-800">{cat.selectedCount}/{cat.items.length}</span>
                       </button>
                       
                       {expandedCategories[cat.label] && (
-                        <div className="px-3 pb-3 space-y-2 border-t border-slate-800/50 pt-2">
+                        <div className="px-4 pb-3 space-y-2 border-t border-slate-800/50 pt-2">
                           {cat.items.map((item, idx) => (
                             <button 
                               key={item.id}
                               onClick={() => toggleDetection(item.id)}
-                              className={`w-full flex items-center justify-between p-2.5 rounded-lg text-[9px] font-bold transition-all ${item.selected ? 'bg-indigo-500/10 border border-indigo-500/20 text-indigo-300' : 'bg-slate-900/40 border border-transparent text-slate-600 hover:border-slate-700'}`}
+                              className={`w-full flex items-center justify-between p-2.5 rounded-lg text-[9px] font-bold transition-all ${item.selected ? 'bg-emerald-500/10 border border-emerald-500/20 text-emerald-300' : 'bg-slate-900/40 border border-transparent text-slate-600 hover:border-slate-700'}`}
                             >
-                              <span className="truncate max-w-[150px]">#{idx + 1} Identifed {cat.label}</span>
-                              {item.selected ? <CheckSquare className="w-3.5 h-3.5" /> : <Square className="w-3.5 h-3.5" />}
+                              <span className="truncate max-w-[150px]">#{idx + 1} Identified {cat.label}</span>
+                              {item.selected ? <CheckSquare className="w-3.5 h-3.5 text-emerald-500" /> : <Square className="w-3.5 h-3.5" />}
                             </button>
                           ))}
                         </div>
                       )}
                     </div>
                   ))
-                ) : state.isAnalyzing ? (
-                  <div className="h-full flex flex-col items-center justify-center opacity-30 italic text-[10px] uppercase tracking-widest gap-4 py-12">
+                ) : isActiveImageAnalyzing ? (
+                  <div className="h-full flex flex-col items-center justify-center opacity-60 text-[11px] uppercase tracking-widest gap-4 py-12">
                     <RefreshCcw className="w-8 h-8 animate-spin text-indigo-500" />
-                    Initializing Neuro-Audit...
+                    Engineering Privacy
                   </div>
                 ) : (
                   <div className="h-full flex flex-col items-center justify-center opacity-20 text-[9px] font-black uppercase tracking-[0.3em] text-center border-2 border-dashed border-slate-800 rounded-3xl m-2 py-12">
                     <Info className="w-8 h-8 mb-4" />
-                    Scan image to see findings
+                    Filtering Data...
                   </div>
                 )}
               </div>
@@ -406,31 +747,31 @@ const App: React.FC = () => {
 
             {/* Action Command Center */}
             <div className="p-6 pt-2 border-t border-slate-800 bg-slate-900 shrink-0 space-y-3">
-              {state.image && !state.isAnalyzing && (
+              {state.image && !isActiveImageAnalyzing && state.detections.length === 0 && (
                 <button 
                   onClick={handleStartScan} 
-                  className={`w-full py-4 rounded-xl font-black text-[10px] uppercase tracking-[0.2em] text-white transition-all flex items-center justify-center gap-2 shadow-xl active:scale-95 ${state.detections.length > 0 ? 'bg-slate-800 hover:bg-slate-700 border border-slate-700' : 'bg-indigo-600 hover:bg-indigo-500 shadow-indigo-500/30'}`}
+                  className="w-full py-4 rounded-xl font-black text-[11px] uppercase tracking-[0.3em] text-white transition-all flex items-center justify-center gap-3 shadow-xl shadow-indigo-500/40 active:scale-95 bg-indigo-600 hover:bg-indigo-500"
                 >
-                  <ScanSearch className="w-4 h-4" /> 
-                  {state.detections.length > 0 ? 'Run New Privacy Scan' : 'Run Privacy Scan'}
+                  <ScanSearch className="w-5 h-5" /> 
+                  Initialize Scan
                 </button>
               )}
 
               {state.detections.length > 0 && (
                 <button 
                   onClick={downloadRedacted} 
-                  className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 rounded-xl font-black text-[10px] uppercase tracking-[0.2em] text-white transition-all flex items-center justify-center gap-2 shadow-xl shadow-emerald-500/20 active:scale-95"
+                  className="w-full py-4 bg-indigo-600 hover:bg-indigo-500 rounded-full font-black text-[11px] uppercase tracking-[0.3em] text-white transition-all flex items-center justify-center gap-3 shadow-xl shadow-indigo-500/40 active:scale-95"
                 >
-                  <Download className="w-4 h-4" /> Download Protected Image
+                  <Download className="w-5 h-5" /> Export Protected
                 </button>
               )}
               
               {state.image && (
                 <button 
                   onClick={removeImage} 
-                  className="w-full py-2.5 border border-slate-800 hover:border-red-500/30 hover:bg-red-500/5 rounded-xl text-[9px] font-black uppercase tracking-[0.2em] text-slate-600 hover:text-red-400 transition-all flex items-center justify-center gap-2"
+                  className="w-full py-4 bg-slate-800 hover:bg-slate-700 rounded-xl font-black text-[11px] uppercase tracking-[0.3em] text-slate-400 hover:text-slate-300 transition-all flex items-center justify-center gap-3"
                 >
-                  <Trash2 className="w-3.5 h-3.5" /> Clear All Data
+                  <Trash2 className="w-5 h-5" /> Discard
                 </button>
               )}
             </div>

--- a/services/gemini.ts
+++ b/services/gemini.ts
@@ -62,11 +62,15 @@ export const analyzeImageForPII = async (base64Image: string): Promise<Detection
   `;
 
   try {
+    // Extract base64 payload without creating an intermediate array (avoid .split())
+    const base64Start = base64Image.indexOf(',');
+    const base64Data = base64Start !== -1 ? base64Image.substring(base64Start + 1) : base64Image;
+
     const response = await ai.models.generateContent({
       model: MODEL_NAME,
       contents: {
         parts: [
-          { inlineData: { data: base64Image.split(',')[1], mimeType: 'image/jpeg' } },
+          { inlineData: { data: base64Data, mimeType: 'image/jpeg' } },
           { text: prompt }
         ]
       },
@@ -110,7 +114,8 @@ export const analyzeImageForPII = async (base64Image: string): Promise<Detection
       };
     });
   } catch (error) {
-    console.error("AI Analysis failed:", error);
+    const errMsg = error instanceof Error ? error.message : (error && typeof error === 'object' ? JSON.stringify(error) : String(error));
+    console.error("AI Analysis failed:", errMsg);
     throw error;
   }
 };

--- a/services/gemini.ts
+++ b/services/gemini.ts
@@ -114,8 +114,8 @@ export const analyzeImageForPII = async (base64Image: string): Promise<Detection
       };
     });
   } catch (error) {
-    const errMsg = error instanceof Error ? error.message : (error && typeof error === 'object' ? JSON.stringify(error) : String(error));
-    console.error("AI Analysis failed:", errMsg);
+    const safeMessage = error instanceof Error ? error.message : String(error ?? 'Unknown error');
+    console.error("AI Analysis failed:", safeMessage);
     throw error;
   }
 };

--- a/services/gemini.ts
+++ b/services/gemini.ts
@@ -24,7 +24,11 @@ const applySafetyBuffer = (box: [number, number, number, number], bufferPercent:
 };
 
 export const analyzeImageForPII = async (base64Image: string): Promise<Detection[]> => {
-  const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing GEMINI_API_KEY");
+  }
+  const ai = new GoogleGenAI({ apiKey });
   
   const prompt = `
     ACT AS A HIGH-PRECISION SECURITY AUDITOR.

--- a/types.ts
+++ b/types.ts
@@ -14,10 +14,22 @@ export interface Detection {
   selected: boolean;
 }
 
+export interface ImageItem {
+  id: string;
+  fileName: string;
+  src: string;
+  file: File;
+  detections: Detection[];
+  isAnalyzing: boolean;
+  error: string | null;
+}
+
 export interface AppState {
   image: string | null;
   fileName: string | null;
   isAnalyzing: boolean;
   detections: Detection[];
   error: string | null;
+  images: ImageItem[];
+  activeImageId: string | null;
 }


### PR DESCRIPTION
### What does this PR do?
Adds support for uploading and processing multiple images (up to 10) in a single session with per-image redaction and status tracking.

### **Why is this needed?**
Currently GuardVision supports only single-image redaction, which limits usability. This enhancement enables batch workflows without breaking the existing single-image flow.

### **Key Changes**
Multi-image upload (max 10 images)
Per-image preview with independent status (pending / redacted)
Sequential processing using existing Gemini redaction logic
Per-image sensitive object detection and masking
No regression to single-image workflow

### **Screenshots**
(Attached in issue https://github.com/SowmyaLR/GuardVision/issues/2)

Closes https://github.com/SowmyaLR/GuardVision/issues/2